### PR TITLE
Set item state for new items

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/server/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/server/feed.go
@@ -229,3 +229,21 @@ func UpdateFeed(c *gin.Context) {
 
 	c.JSON(200, &feed)
 }
+
+func GetFeedsUsers(c *gin.Context) {
+	feed := c.MustGet("feed").(*Feed)
+	var user []User
+
+	query := bson.M{
+		"feedids": bson.M{
+			"$in": []bson.ObjectId{feed.ID},
+		},
+	}
+
+	if err := users().Find(query).All(&user); err != nil {
+		c.AbortWithError(500, err)
+		return
+	}
+
+	c.JSON(200, &user)
+}

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -109,6 +109,11 @@ func main() {
 		Unique: true,
 	})
 
+	ensureIndex(users(), mgo.Index{
+		Key:    []string{"feedids"},
+		Unique: true,
+	})
+
 	ensureIndex(feeds(), mgo.Index{
 		Key:      []string{"url"},
 		Unique:   true,
@@ -144,6 +149,7 @@ func main() {
 
 	api.POST("/feeds", CreateFeed)
 	api.GET("/feeds/:id", RequireValidFeedID, ReadFeed)
+	api.GET("/feeds/:id/users", RequireValidFeedID, GetFeedsUsers)
 	api.GET("/feeds", FindFeed)
 	api.PUT("/feeds/:id", RequireValidFeedID, UpdateFeed)
 

--- a/src/github.com/cjlucas/unnamedcast/worker/workers.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers.go
@@ -318,7 +318,7 @@ func (w *UpdateFeedWorker) Work(q *koda.Queue, j *koda.Job) error {
 		}
 
 		if err := api.PutItemStates(user.ID, user.ItemStates); err != nil {
-			fmt.Println("Error saving states. Will continue:", err)
+			fmt.Println("Error saving states (will continue):", err)
 			continue
 		}
 	}


### PR DESCRIPTION
When new items are added. Users subscribed to that item's feed will expect that item to be marked as unplayed.

To do this, a new endpoint needs to be created. `/api/feeds/:id/users` will return an array of all the users subscribed to that feed.

`UpdateFeedWorker` will be in charge of adding this unplayed state whenever a new item is discovered.