### PR TITLE
Seperate feed items into their own collection

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/server/app_test.go
+++ b/src/github.com/cjlucas/unnamedcast/server/app_test.go
@@ -350,86 +350,6 @@ func TestPutUserItemStates(t *testing.T) {
 	}
 }
 
-func TestGetUserFeedItems(t *testing.T) {
-	app := newTestApp()
-	user := createUser(t, app, "chris", "password")
-	item := createItem(t, app, &db.Item{
-		GUID: "http://google.com/item",
-	})
-	feed := createFeed(t, app, &db.Feed{
-		URL:   "http://google.com",
-		Items: []bson.ObjectId{item.ID},
-	})
-
-	user.FeedIDs = append(user.FeedIDs, feed.ID)
-	if err := app.DB.UpdateUser(user); err != nil {
-		t.Fatal("Could not update feed")
-	}
-
-	req := newRequest("GET", fmt.Sprintf("/api/users/%s/items", user.ID.Hex()), nil)
-	var items []db.Item
-	testEndpoint(t, endpointTestInfo{
-		App:          app,
-		Request:      req,
-		ExpectedCode: http.StatusOK,
-		ResponseBody: &items,
-	})
-
-	if len(items) != 1 {
-		t.Errorf("items len mismatch: %d != %d", len(items), 1)
-		if items[0].ID != feed.Items[0] {
-			t.Errorf("item id mismatch: %s != %s", items[0].ID, feed.Items[0])
-		}
-	}
-}
-
-func TestGetUserFeedItemsWithModTime(t *testing.T) {
-	app := newTestApp()
-	user := createUser(t, app, "chris", "password")
-	item := createItem(t, app, &db.Item{
-		GUID: "http://google.com/item",
-	})
-	feed := createFeed(t, app, &db.Feed{
-		URL:   "http://google.com",
-		Items: []bson.ObjectId{item.ID},
-	})
-
-	user.FeedIDs = append(user.FeedIDs, feed.ID)
-	if err := app.DB.UpdateUser(user); err != nil {
-		t.Fatal("Could not update feed")
-	}
-
-	modTime := item.ModificationTime.Add(1 * time.Second)
-	url := fmt.Sprintf("/api/users/%s/items?modified_since=%s", user.ID.Hex(), modTime.Format(time.RFC3339))
-	req := newRequest("GET", url, nil)
-	var items []db.Item
-	testEndpoint(t, endpointTestInfo{
-		App:          app,
-		Request:      req,
-		ExpectedCode: http.StatusOK,
-		ResponseBody: &items,
-	})
-
-	if len(items) != 0 {
-		t.Errorf("items len mismatch: %d != %d", len(items), 0)
-	}
-
-	modTime = item.ModificationTime.Add(-2 * time.Second)
-	url = fmt.Sprintf("/api/users/%s/items?modified_since=%s", user.ID.Hex(), modTime.Format(time.RFC3339))
-	req = newRequest("GET", url, nil)
-	items = []db.Item{}
-	testEndpoint(t, endpointTestInfo{
-		App:          app,
-		Request:      req,
-		ExpectedCode: http.StatusOK,
-		ResponseBody: &items,
-	})
-
-	if len(items) != 1 {
-		t.Errorf("items len mismatch: %d != %d", len(items), 1)
-	}
-}
-
 func TestCreateFeed(t *testing.T) {
 	in := db.Feed{URL: "http://google.com"}
 
@@ -567,6 +487,74 @@ func TestPutFeed(t *testing.T) {
 		Request:      newRequest("PUT", url, nil),
 		ExpectedCode: http.StatusBadRequest,
 	})
+}
+
+func TestGetUserFeedItems(t *testing.T) {
+	app := newTestApp()
+	item := createItem(t, app, &db.Item{
+		GUID: "http://google.com/item",
+	})
+	feed := createFeed(t, app, &db.Feed{
+		URL:   "http://google.com",
+		Items: []bson.ObjectId{item.ID},
+	})
+
+	req := newRequest("GET", fmt.Sprintf("/api/feeds/%s/items", feed.ID.Hex()), nil)
+	var items []db.Item
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      req,
+		ExpectedCode: http.StatusOK,
+		ResponseBody: &items,
+	})
+
+	if len(items) != 1 {
+		t.Errorf("items len mismatch: %d != %d", len(items), 1)
+		if items[0].ID != feed.Items[0] {
+			t.Errorf("item id mismatch: %s != %s", items[0].ID, feed.Items[0])
+		}
+	}
+}
+
+func TestGetUserFeedItemsWithModTime(t *testing.T) {
+	app := newTestApp()
+	item := createItem(t, app, &db.Item{
+		GUID: "http://google.com/item",
+	})
+	feed := createFeed(t, app, &db.Feed{
+		URL:   "http://google.com",
+		Items: []bson.ObjectId{item.ID},
+	})
+
+	modTime := item.ModificationTime.Add(1 * time.Second)
+	url := fmt.Sprintf("/api/feeds/%s/items?modified_since=%s", feed.ID.Hex(), modTime.Format(time.RFC3339))
+	req := newRequest("GET", url, nil)
+	var items []db.Item
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      req,
+		ExpectedCode: http.StatusOK,
+		ResponseBody: &items,
+	})
+
+	if len(items) != 0 {
+		t.Errorf("items len mismatch: %d != %d", len(items), 0)
+	}
+
+	modTime = item.ModificationTime.Add(-2 * time.Second)
+	url = fmt.Sprintf("/api/feeds/%s/items?modified_since=%s", feed.ID.Hex(), modTime.Format(time.RFC3339))
+	req = newRequest("GET", url, nil)
+	items = []db.Item{}
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      req,
+		ExpectedCode: http.StatusOK,
+		ResponseBody: &items,
+	})
+
+	if len(items) != 1 {
+		t.Errorf("items len mismatch: %d != %d", len(items), 1)
+	}
 }
 
 func TestGetFeedsUsers(t *testing.T) {

--- a/src/github.com/cjlucas/unnamedcast/server/app_test.go
+++ b/src/github.com/cjlucas/unnamedcast/server/app_test.go
@@ -549,6 +549,29 @@ func TestCreateFeedItem(t *testing.T) {
 	}
 }
 
+func TestGetFeedItem(t *testing.T) {
+	app := newTestApp()
+	item := createItem(t, app, &db.Item{GUID: "http://google.com/item"})
+	feed := createFeed(t, app, &db.Feed{
+		URL:   "http://google.com",
+		Items: []bson.ObjectId{item.ID},
+	})
+
+	url := fmt.Sprintf("/api/feeds/%s/items/%s", feed.ID.Hex(), item.ID.Hex())
+	req := newRequest("GET", url, item)
+	var out db.Item
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      req,
+		ExpectedCode: http.StatusOK,
+		ResponseBody: &out,
+	})
+
+	if out.GUID != item.GUID {
+		t.Errorf("GUID mismatch: %s != %s", out.GUID, item.GUID)
+	}
+}
+
 func TestPutFeedItem(t *testing.T) {
 	app := newTestApp()
 	item := createItem(t, app, &db.Item{GUID: "http://google.com/item"})

--- a/src/github.com/cjlucas/unnamedcast/server/db/db.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/db.go
@@ -54,6 +54,8 @@ func (db *DB) db() *mgo.Database {
 	return db.s.DB("")
 }
 
+// TODO(clucas): Move this method to be a member of DB and use this
+// function to wrap all Create* and Update* methods
 func (q *query) handleDBError(f func() error) error {
 	i := 0
 	err := f()

--- a/src/github.com/cjlucas/unnamedcast/server/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/feed.go
@@ -152,11 +152,3 @@ func (db *DB) FindItems(q interface{}) Query {
 func (db *DB) FindItemByID(id bson.ObjectId) Query {
 	return db.FindItems(bson.M{"_id": id})
 }
-
-func (db *DB) FindItemsWithIDs(ids []bson.ObjectId) Query {
-	return db.FindItems(bson.M{
-		"_id": bson.M{
-			"$in": ids,
-		},
-	})
-}

--- a/src/github.com/cjlucas/unnamedcast/server/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/feed.go
@@ -12,7 +12,7 @@ type Feed struct {
 	Title             string          `json:"title" bson:"title"`
 	URL               string          `json:"url" bson:"url"`
 	Author            string          `json:"author" bson:"author"`
-	Items             []bson.ObjectId `json:"-" bson:"items"`
+	Items             []bson.ObjectId `json:"items" bson:"items"`
 	CreationTime      time.Time       `json:"creation_time" bson:"creation_time"`
 	ModificationTime  time.Time       `json:"modification_time" bson:"modification_time"`
 	ImageURL          string          `json:"image_url" bson:"image_url"`
@@ -47,6 +47,7 @@ type Item struct {
 	Duration         time.Duration `json:"duration" bson:"duration"`
 	Size             int           `json:"size" bson:"size"`
 	PublicationTime  time.Time     `json:"publication_time" bson:"publication_time"`
+	CreationTime     time.Time     `json:"creation_time" bson:"creation_time"`
 	ModificationTime time.Time     `json:"modification_time" bson:"modification_time"`
 	ImageURL         string        `json:"image_url" bson:"image_url"`
 }
@@ -76,6 +77,8 @@ func (db *DB) FeedByID(id bson.ObjectId) (*Feed, error) {
 
 func (db *DB) CreateFeed(feed *Feed) error {
 	feed.ID = bson.NewObjectId()
+	feed.CreationTime = time.Now().UTC()
+	feed.ModificationTime = time.Now().UTC()
 	return db.feeds().Insert(feed)
 }
 
@@ -119,6 +122,8 @@ func (db *DB) items() *mgo.Collection {
 
 func (db *DB) CreateItem(item *Item) error {
 	item.ID = bson.NewObjectId()
+	item.CreationTime = time.Now().UTC()
+	item.ModificationTime = time.Now().UTC()
 	return db.items().Insert(item)
 }
 

--- a/src/github.com/cjlucas/unnamedcast/server/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/feed.go
@@ -26,6 +26,16 @@ type Feed struct {
 	} `json:"category"`
 }
 
+func (f *Feed) HasItemWithID(id bson.ObjectId) bool {
+	for i := range f.Items {
+		if f.Items[i] == id {
+			return true
+		}
+	}
+
+	return false
+}
+
 type Item struct {
 	ID               bson.ObjectId `json:"id" bson:"_id,omitempty"`
 	GUID             string        `json:"guid" bson:"guid"`
@@ -125,7 +135,7 @@ func (db *DB) UpdateItem(item *Item) error {
 	// This would have to be done at a choke point like the JSON/BSON
 	// [un]marshallers
 	item.PublicationTime = item.PublicationTime.UTC()
-	if CopyModel(origItem, item, "CreationTime", "ModificationTime") {
+	if CopyModel(&origItem, item, "CreationTime", "ModificationTime") {
 		item.ModificationTime = time.Now().UTC()
 	}
 

--- a/src/github.com/cjlucas/unnamedcast/server/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/feed.go
@@ -8,17 +8,17 @@ import (
 )
 
 type Feed struct {
-	ID                bson.ObjectId `bson:"_id,omitempty" json:"id"`
-	Title             string        `json:"title" bson:"title"`
-	URL               string        `json:"url" bson:"url"`
-	Author            string        `json:"author" bson:"author"`
-	Items             []Item        `json:"items" bson:"items"`
-	CreationTime      time.Time     `json:"creation_time" bson:"creation_time"`
-	ModificationTime  time.Time     `json:"modification_time" bson:"modification_time"`
-	ImageURL          string        `json:"image_url" bson:"image_url"`
-	ITunesID          int           `json:"itunes_id" bson:"itunes_id"`
-	ITunesReviewCount int           `json:"itunes_review_count" bson:"itunes_review_count"`
-	ITunesRatingCount int           `json:"itunes_rating_count" bson:"itunes_rating_count"`
+	ID                bson.ObjectId   `bson:"_id,omitempty" json:"id"`
+	Title             string          `json:"title" bson:"title"`
+	URL               string          `json:"url" bson:"url"`
+	Author            string          `json:"author" bson:"author"`
+	Items             []bson.ObjectId `json:"-" bson:"items"`
+	CreationTime      time.Time       `json:"creation_time" bson:"creation_time"`
+	ModificationTime  time.Time       `json:"modification_time" bson:"modification_time"`
+	ImageURL          string          `json:"image_url" bson:"image_url"`
+	ITunesID          int             `json:"itunes_id" bson:"itunes_id"`
+	ITunesReviewCount int             `json:"itunes_review_count" bson:"itunes_review_count"`
+	ITunesRatingCount int             `json:"itunes_rating_count" bson:"itunes_rating_count"`
 
 	Category struct {
 		Name          string   `json:"name" bson:"name"`
@@ -27,6 +27,7 @@ type Feed struct {
 }
 
 type Item struct {
+	ID               bson.ObjectId `json:"id" bson:"_id,omitempty"`
 	GUID             string        `json:"guid" bson:"guid"`
 	Link             string        `json:"link" bson:"link"`
 	Title            string        `json:"title" bson:"title"`
@@ -38,15 +39,6 @@ type Item struct {
 	PublicationTime  time.Time     `json:"publication_time" bson:"publication_time"`
 	ModificationTime time.Time     `json:"modification_time" bson:"modification_time"`
 	ImageURL         string        `json:"image_url" bson:"image_url"`
-}
-
-func generateGUIDToItemMap(items []Item) map[string]*Item {
-	guidMap := make(map[string]*Item)
-	for i := range items {
-		guidMap[items[i].GUID] = &items[i]
-	}
-
-	return guidMap
 }
 
 func (db *DB) feeds() *mgo.Collection {
@@ -83,7 +75,7 @@ func (db *DB) UpdateFeed(feed *Feed) error {
 		return err
 	}
 
-	ignoredFields := []string{"ID", "Items", "CreationTime", "ModificationTime"}
+	ignoredFields := []string{"ID", "CreationTime", "ModificationTime"}
 
 	// Ignore Category if both are equal in the case where both subcats are 0 len
 	// This is necessary due to how DeepEqual and JSON/BSON unmarshalling work.
@@ -100,36 +92,7 @@ func (db *DB) UpdateFeed(feed *Feed) error {
 		ignoredFields = append(ignoredFields, "Category")
 	}
 
-	didChange := CopyModel(&origFeed, feed, ignoredFields...)
-	itemGUIDMap := generateGUIDToItemMap(origFeed.Items)
-
-	// TODO(clucas): Refactor to copy items from origFeed into
-	// feed and update with new feed instead of old
-	for i := range feed.Items {
-		item := &feed.Items[i]
-		// Time needs to be UTC because CopyModel will detect
-		// a change if the time zones don't match.
-		//
-		// An alternate solution would be require UTC for all times, everywhere.
-		// This would have to be done at a choke point like the JSON/BSON
-		// [un]marshallers
-		item.PublicationTime = item.PublicationTime.UTC()
-
-		if origItem := itemGUIDMap[item.GUID]; origItem != nil {
-			// If Item already existed, copy the new feed data over
-			if CopyModel(origItem, item, "ModificationTime") {
-				origItem.ModificationTime = time.Now().UTC()
-				didChange = true
-			}
-		} else {
-			// If Item is new, append it to the Item list
-			item.ModificationTime = time.Now().UTC()
-			origFeed.Items = append(origFeed.Items, *item)
-			didChange = true
-		}
-	}
-
-	if didChange {
+	if CopyModel(&origFeed, feed, ignoredFields...) {
 		origFeed.ModificationTime = time.Now().UTC()
 	}
 
@@ -138,4 +101,52 @@ func (db *DB) UpdateFeed(feed *Feed) error {
 
 func (db *DB) EnsureFeedIndex(idx Index) error {
 	return db.feeds().EnsureIndex(mgoIndexForIndex(idx))
+}
+
+func (db *DB) items() *mgo.Collection {
+	return db.db().C("items")
+}
+
+func (db *DB) CreateItem(item *Item) error {
+	item.ID = bson.NewObjectId()
+	return db.items().Insert(item)
+}
+
+func (db *DB) UpdateItem(item *Item) error {
+	var origItem Item
+	if err := db.FindItemByID(item.ID).One(&origItem); err != nil {
+		return err
+	}
+
+	// Time needs to be UTC because CopyModel will detect
+	// a change if the time zones don't match.
+	//
+	// An alternate solution would be require UTC for all times, everywhere.
+	// This would have to be done at a choke point like the JSON/BSON
+	// [un]marshallers
+	item.PublicationTime = item.PublicationTime.UTC()
+	if CopyModel(origItem, item, "CreationTime", "ModificationTime") {
+		item.ModificationTime = time.Now().UTC()
+	}
+
+	return db.items().UpdateId(item.ID, item)
+}
+
+func (db *DB) FindItems(q interface{}) Query {
+	return &query{
+		s: db.s,
+		q: db.items().Find(q),
+	}
+}
+
+func (db *DB) FindItemByID(id bson.ObjectId) Query {
+	return db.FindItems(bson.M{"_id": id})
+}
+
+func (db *DB) FindItemsWithIDs(ids []bson.ObjectId) Query {
+	return db.FindItems(bson.M{
+		"_id": bson.M{
+			"$in": ids,
+		},
+	})
 }

--- a/src/github.com/cjlucas/unnamedcast/tools/api/main.go
+++ b/src/github.com/cjlucas/unnamedcast/tools/api/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/cjlucas/unnamedcast/koda"
+	"github.com/cjlucas/unnamedcast/worker/api"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: api <url>")
+		os.Exit(1)
+	}
+
+	koda.Configure(&koda.Options{
+		URL: "redis://192.168.1.21:6379",
+	})
+
+	baseURL, err := url.Parse("http://192.168.1.21")
+	if err != nil {
+		panic(err)
+	}
+	apiTransport := api.API{BaseURL: baseURL}
+
+	url := os.Args[1]
+	feed, err := apiTransport.CreateFeed(&api.Feed{
+		URL: url,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(feed)
+	koda.Submit("update-feed", 100, map[string]string{
+		"feed_id": feed.ID,
+	})
+}

--- a/src/github.com/cjlucas/unnamedcast/worker/api/api.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/api/api.go
@@ -40,6 +40,7 @@ type Feed struct {
 	ITunesRatingCount int       `json:"itunes_rating_count"`
 	CreationTime      time.Time `json:"creation_time"`
 	ModificationTime  time.Time `json:"modification_time"`
+	Items             []string  `json:"items"`
 
 	Category struct {
 		Name          string   `json:"name"`
@@ -167,6 +168,25 @@ func (api *API) FeedForURL(feedURL string) (*Feed, error) {
 		return nil, err
 	}
 	return &feeds[0], err
+}
+
+func (api *API) CreateFeedItem(feedID string, item *Item) error {
+	return api.makeRequest(&apiRoundTrip{
+		Method:      "POST",
+		Endpoint:    fmt.Sprintf("/api/feeds/%s/items", feedID),
+		RequestBody: item,
+	})
+}
+
+func (api *API) UpdateFeedItem(feedID string, item *Item) (*Item, error) {
+	var out Item
+	err := api.makeRequest(&apiRoundTrip{
+		Method:       "PUT",
+		Endpoint:     fmt.Sprintf("/api/feeds/%s/items/%s", feedID, item.ID),
+		RequestBody:  item,
+		ResponseBody: &out,
+	})
+	return &out, err
 }
 
 func (api *API) GetFeedItems(feedID string) ([]Item, error) {

--- a/src/github.com/cjlucas/unnamedcast/worker/api/api.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/api/api.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -30,15 +30,16 @@ type ItemState struct {
 }
 
 type Feed struct {
-	ID                string `json:"id,omitempty"`
-	Title             string `json:"title"`
-	URL               string `json:"url"`
-	Author            string `json:"author"`
-	Items             []Item `json:"items"`
-	ImageURL          string `json:"image_url"`
-	ITunesID          int    `json:"itunes_id"`
-	ITunesReviewCount int    `json:"itunes_review_count"`
-	ITunesRatingCount int    `json:"itunes_rating_count"`
+	ID                string    `json:"id,omitempty"`
+	Title             string    `json:"title"`
+	URL               string    `json:"url"`
+	Author            string    `json:"author"`
+	ImageURL          string    `json:"image_url"`
+	ITunesID          int       `json:"itunes_id"`
+	ITunesReviewCount int       `json:"itunes_review_count"`
+	ITunesRatingCount int       `json:"itunes_rating_count"`
+	CreationTime      time.Time `json:"creation_time"`
+	ModificationTime  time.Time `json:"modification_time"`
 
 	Category struct {
 		Name          string   `json:"name"`
@@ -47,124 +48,104 @@ type Feed struct {
 }
 
 type Item struct {
-	GUID            string        `json:"guid"`
-	Link            string        `json:"link"`
-	Title           string        `json:"title"`
-	Description     string        `json:"description"`
-	URL             string        `json:"url"`
-	Author          string        `json:"author"`
-	Duration        time.Duration `json:"duration"`
-	Size            int           `json:"size"`
-	PublicationTime time.Time     `json:"publication_time"`
-	ImageURL        string        `json:"image_url"`
+	ID               string        `json:"id,omitempty"`
+	GUID             string        `json:"guid"`
+	Link             string        `json:"link"`
+	Title            string        `json:"title"`
+	Description      string        `json:"description"`
+	URL              string        `json:"url"`
+	Author           string        `json:"author"`
+	Duration         time.Duration `json:"duration"`
+	Size             int           `json:"size"`
+	PublicationTime  time.Time     `json:"publication_time"`
+	ImageURL         string        `json:"image_url"`
+	CreationTime     time.Time     `json:"creation_time"`
+	ModificationTime time.Time     `json:"modification_time"`
 }
 
 type API struct {
 	BaseURL *url.URL
 }
 
-func (api *API) urlf(fmtStr string, vals ...interface{}) string {
-	fmtStr = fmt.Sprintf("%s%s", api.BaseURL, fmtStr)
-	return fmt.Sprintf(fmtStr, vals...)
+type apiRoundTrip struct {
+	Method       string
+	Endpoint     string
+	RequestBody  interface{}
+	Response     *http.Response
+	ResponseBody interface{}
 }
 
-func (api *API) GetFeed(feedID string) (*Feed, error) {
-	url := api.urlf("/api/feeds/%s", feedID)
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return nil, err
+func (api *API) makeRequest(apiReq *apiRoundTrip) error {
+	var reqBody io.Reader
+	if apiReq.RequestBody != nil {
+		data, err := json.Marshal(apiReq.RequestBody)
+		if err != nil {
+			return err
+		}
+		reqBody = bytes.NewReader(data)
 	}
 
-	defer resp.Body.Close()
-	data, _ := ioutil.ReadAll(resp.Body)
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("failed to get feed (code: %d)", resp.StatusCode)
-	}
-
-	var feed Feed
-	if err := json.Unmarshal(data, &feed); err != nil {
-		return nil, err
-	}
-
-	return &feed, nil
-}
-
-func (api *API) UpdateFeed(feed *Feed) error {
-	payload, err := json.Marshal(&feed)
+	url := fmt.Sprintf("%s%s", api.BaseURL, apiReq.Endpoint)
+	req, err := http.NewRequest(apiReq.Method, url, reqBody)
 	if err != nil {
 		return err
 	}
-
-	r := bytes.NewReader(payload)
-	url := api.urlf("/api/feeds/%s", feed.ID)
-	req, err := http.NewRequest("PUT", url, r)
-	if err != nil {
-		return err
-	}
-
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		if err, ok := err.(*net.DNSError); ok {
-			panic(fmt.Sprintf("TURNS OUT IT IS A DNS error: %s", err))
-		}
 		return err
 	}
+	data, _ := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
-	// Read entire response to prevent broken pipe
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
+	apiReq.Response = resp
 
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("Received unexpected status code with body: %s", data)
+	if apiReq.ResponseBody != nil {
+		if err := json.Unmarshal(data, apiReq.ResponseBody); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
+func (api *API) GetFeed(feedID string) (*Feed, error) {
+	var feed Feed
+	err := api.makeRequest(&apiRoundTrip{
+		Method:       "GET",
+		Endpoint:     fmt.Sprintf("/api/feeds/%s", feedID),
+		ResponseBody: &feed,
+	})
+	return &feed, err
+}
+
+func (api *API) UpdateFeed(feed *Feed) error {
+	return api.makeRequest(&apiRoundTrip{
+		Method:      "PUT",
+		Endpoint:    fmt.Sprintf("/api/feeds/%s", feed.ID),
+		RequestBody: feed,
+	})
+}
+
 func (api *API) CreateFeed(feed *Feed) (*Feed, error) {
-	payload, err := json.Marshal(&feed)
-	if err != nil {
-		return nil, err
-	}
-
-	r := bytes.NewReader(payload)
-	apiURL := api.urlf("/api/feeds")
-	resp, err := httpClient.Post(apiURL, "application/json", r)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// Read entire response to prevent broken pipe
-	data, _ := ioutil.ReadAll(resp.Body)
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Received unexpected status code with body: %s", data)
-	}
-
-	if err := json.Unmarshal(data, feed); err != nil {
-		return nil, err
-	}
-
-	return feed, nil
+	var respFeed Feed
+	err := api.makeRequest(&apiRoundTrip{
+		Method:       "POST",
+		Endpoint:     "/api/feeds",
+		RequestBody:  feed,
+		ResponseBody: &respFeed,
+	})
+	return &respFeed, err
 }
 
 func (api *API) feedExistsWithKey(key, value string) (bool, error) {
-	url := api.urlf("/api/feeds?%s=%s", key, value)
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return false, err
+	req := apiRoundTrip{
+		Method:   "GET",
+		Endpoint: fmt.Sprintf("/api/feeds?%s=%s", key, value),
 	}
-	defer resp.Body.Close()
-	ioutil.ReadAll(resp.Body)
-
-	return resp.StatusCode == 200, nil
+	err := api.makeRequest(&req)
+	return req.Response.StatusCode == http.StatusOK, err
 }
 
 func (api *API) FeedExistsWithURL(url string) (bool, error) {
@@ -176,103 +157,52 @@ func (api *API) FeedExistsWithiTunesID(id int) (bool, error) {
 }
 
 func (api *API) FeedForURL(feedURL string) (*Feed, error) {
-	url := api.urlf("/api/feeds?url=%s", feedURL)
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Received unexpected status code: %d", resp.StatusCode)
-	}
-
 	var feeds []Feed
-	if err := json.Unmarshal(data, &feeds); err != nil {
+	err := api.makeRequest(&apiRoundTrip{
+		Method:       "GET",
+		Endpoint:     fmt.Sprintf("/api/feeds?url=%s", feedURL),
+		ResponseBody: &feeds,
+	})
+	if len(feeds) == 0 {
 		return nil, err
 	}
+	return &feeds[0], err
+}
 
-	if len(feeds) == 0 {
-		return nil, nil
-	}
-
-	return &feeds[0], nil
+func (api *API) GetFeedItems(feedID string) ([]Item, error) {
+	var items []Item
+	err := api.makeRequest(&apiRoundTrip{
+		Method:       "GET",
+		Endpoint:     fmt.Sprintf("/api/feeds/%s/items", feedID),
+		ResponseBody: &items,
+	})
+	return items, err
 }
 
 func (api *API) GetFeedsUsers(feedID string) ([]User, error) {
-	url := api.urlf("/api/feeds/%s/users", feedID)
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Received unexpected status code: %d", resp.StatusCode)
-	}
-
 	var users []User
-	if err := json.Unmarshal(data, &users); err != nil {
-		return nil, err
-	}
-
-	return users, nil
+	err := api.makeRequest(&apiRoundTrip{
+		Method:       "GET",
+		Endpoint:     fmt.Sprintf("/api/feeds/%s/users", feedID),
+		ResponseBody: &users,
+	})
+	return users, err
 }
 
 func (api *API) PutItemStates(userID string, states []ItemState) error {
-	data, err := json.Marshal(states)
-	if err != nil {
-		return err
-	}
-
-	url := api.urlf("/api/users/%s/states", userID)
-	r := bytes.NewReader(data)
-	req, err := http.NewRequest("PUT", url, r)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("Received unexpected status code: %d", resp.StatusCode)
-	}
-
-	return nil
+	return api.makeRequest(&apiRoundTrip{
+		Method:      "PUT",
+		Endpoint:    fmt.Sprintf("/api/users/%s/states", userID),
+		RequestBody: &states,
+	})
 }
 
 func (api *API) GetUsers() ([]User, error) {
 	var users []User
-	resp, err := http.Get(api.urlf("/api/feeds"))
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-	data, _ := ioutil.ReadAll(resp.Body)
-
-	if err := json.Unmarshal(data, &users); err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Received unexpected status code: %d", resp.StatusCode)
-	}
-
-	return users, nil
+	err := api.makeRequest(&apiRoundTrip{
+		Method:       "GET",
+		Endpoint:     "/api/users",
+		ResponseBody: &users,
+	})
+	return users, err
 }

--- a/src/github.com/cjlucas/unnamedcast/worker/api/api_test.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/api/api_test.go
@@ -1,28 +1,5 @@
 package api
 
-import (
-	"net/url"
-	"testing"
-)
+import "net/url"
 
 var baseURL = url.URL{Scheme: "http", Host: "localhost:8080"}
-
-func TestUrlf(t *testing.T) {
-	api := API{BaseURL: &baseURL}
-
-	cases := []struct {
-		actual   string
-		expected string
-	}{
-		{
-			api.urlf("/api/feeds/%d", 123),
-			"http://localhost:8080/api/feeds/123",
-		},
-	}
-
-	for _, c := range cases {
-		if c.actual != c.expected {
-			t.Errorf("%s != %s", c.actual, c.expected)
-		}
-	}
-}

--- a/src/github.com/cjlucas/unnamedcast/worker/workers_test.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers_test.go
@@ -5,50 +5,10 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/cjlucas/unnamedcast/worker/api"
 	"github.com/cjlucas/unnamedcast/worker/rss"
 )
 
-func TestUpdateFeedWorker_mergeFeeds(t *testing.T) {
-	f1 := api.Feed{
-		Items: []api.Item{
-			{GUID: "1", Title: "1"},
-			{GUID: "2", Title: "2"},
-			{GUID: "3", Title: "3"},
-		},
-	}
-
-	f2 := api.Feed{
-		Items: []api.Item{
-			{GUID: "3", Title: "4"},
-			{GUID: "4", Title: "5"},
-			{GUID: "5", Title: "6"},
-		},
-	}
-
-	w := UpdateFeedWorker{}
-	f := w.mergeFeeds(&f1, &f2)
-	if len(f.Items) != 5 {
-		t.Errorf("Resulting feed should have 5 items, has %d", len(f.Items))
-	}
-
-	guidMap := make(map[string]*api.Item)
-	for i := range f.Items {
-		guidMap[f.Items[i].GUID] = &f.Items[i]
-	}
-
-	for _, s := range []string{"1", "2", "3", "4", "5"} {
-		if _, ok := guidMap[s]; !ok {
-			t.Errorf("Expected item with GUID \"%s\" to exist", s)
-		}
-	}
-
-	if guidMap["3"].Title != "4" {
-		t.Errorf("Expected duplicate item to overrwrite with new information")
-	}
-}
-
-func TestRssDocumentToAPIPayloadDescription(t *testing.T) {
+func TestItemsFromRSSWithDescription(t *testing.T) {
 	buf, err := ioutil.ReadFile("testdata/nominal.xml")
 	if err != nil {
 		t.Fatal(err)
@@ -58,13 +18,9 @@ func TestRssDocumentToAPIPayloadDescription(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	items := itemsFromRSS(doc)
 
-	feed, err := rssDocumentToAPIPayload(doc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if feed.Items[0].Description != doc.Channel.Items[0].ContentEncoded {
+	if items[0].Description != doc.Channel.Items[0].ContentEncoded {
 		t.Error("item.Description != item.ContentEncoded")
 	}
 }

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       - REDIS_URL=redis://rdb:6379
   redis:
     image: redis
+    ports:
+      - "6379:6379"
   mongodb:
     image: mongo
     ports:


### PR DESCRIPTION
As discovered during the server refactor, the reason for the `io.EOF` response from MongoDB was that the server was attempting to insert a `Feed` that surpassed the maximum document size for Mongo. This issue addresses this limitation.

The solution would be to separate `Item` out into its own collection and have `Feed` store references to its items. This change is non-trivial and will have an impact an all aspects of the system. Below is an exploration of how each component will have to be modified to support this change.

**Update Feed Worker**
- New flow
  - Fetch existing feed
  - Fetch RSS document
  - Scan RSS document for GUIDs not present in existing feed
  - POST new items (if any)
  - PUT any previously existing items
  - PUT feed

**Server**
- Struct fields
  - `Feed.Items` should be changed to type `[]bson.ObjectId`
    - ~~DB implementation detail; not part of API~~
    - **Update:** This will be part of the API, but will be treated as an immutable property. Any attempt to modify it via PUT or POST will result in a `http.StatusConflict`.
  - `Item.ID`
  - `Item.FeedID`
    - This would only be for traceability/debugging purposes as new endpoints outlined below require all interactions with an item to go through `/api/feeds/:id/items/*`
    - DB space should be a consideration as ObjectIds are 12 bytes each
- New endpoints
  - `GET /feeds/:id/items` (with optional `modified_since` param)
  - `POST /feeds/:id/items`
    - Route will create the new item and append new item's ID to `Feed.Items`
  - `PUT /feeds/:id/items`
  - `GET /feeds/:feed_id/items/:item_id`
- Modified endpoints
  - `[GET|PUT|POST] /feeds/[:id]` should remove all handling of feed items

**Client's Sync Engine**
- New flow
  - `GET /users/:id/feeds`
  - `GET /feeds/:id/items` for each feed (using `modified_since` on subsequent syncs)