### PR TITLE
Handle/log application errors

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/server/app_test.go
+++ b/src/github.com/cjlucas/unnamedcast/server/app_test.go
@@ -203,10 +203,11 @@ func TestCreateUserValidParams(t *testing.T) {
 		t.Error("user.ID is invalid")
 	}
 
+	// Duplicate entry
 	testEndpoint(t, endpointTestInfo{
 		App:          app,
 		Request:      req,
-		ExpectedCode: http.StatusInternalServerError,
+		ExpectedCode: http.StatusConflict,
 	})
 
 	// No parameters
@@ -367,6 +368,20 @@ func TestCreateFeed(t *testing.T) {
 	if out.URL != in.URL {
 		t.Errorf("URL mismatch: %s != %s", out.URL, in.URL)
 	}
+
+	// Duplicate entry
+	app := newTestApp()
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      newRequest("POST", "/api/feeds", &in),
+		ExpectedCode: http.StatusOK,
+	})
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      newRequest("POST", "/api/feeds", &in),
+		ExpectedCode: http.StatusConflict,
+	})
+	app.DB.Drop()
 
 	// No body given
 	testEndpoint(t, endpointTestInfo{

--- a/src/github.com/cjlucas/unnamedcast/server/db/db.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/db.go
@@ -9,6 +9,10 @@ import (
 
 var ErrNotFound = mgo.ErrNotFound
 
+func IsDup(err error) bool {
+	return mgo.IsDup(err)
+}
+
 type DB struct {
 	s *mgo.Session
 }

--- a/src/github.com/cjlucas/unnamedcast/server/db/db.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/db.go
@@ -7,6 +7,8 @@ import (
 	"gopkg.in/mgo.v2"
 )
 
+var ErrNotFound = mgo.ErrNotFound
+
 type DB struct {
 	s *mgo.Session
 }

--- a/src/github.com/cjlucas/unnamedcast/server/db/log.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/log.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"time"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type Log struct {
+	ID            bson.ObjectId       `bson:"_id,omitempty" json:"id"`
+	Method        string              `bson:"method" json:"method"`
+	RequestHeader map[string][]string `bson:"request_header" json:"request_header"`
+	RequestBody   string              `bson:"request_body" json:"request_body"`
+	URL           string              `bson:"url" json:"url"`
+	StatusCode    int                 `bson:"status_code" json:"status_code"`
+	RemoteAddr    string              `bson:"remote_addr" json:"remote_addr"`
+	Errors        interface{}         `bson:"errors" json:"errors"`
+	CreationTime  time.Time           `bson:"creation_time" json:"creation_time"`
+}
+
+func (db *DB) log() *mgo.Collection {
+	return db.db().C("logs")
+}
+
+func (db *DB) FindLogs(q interface{}) Query {
+	return &query{
+		s: db.s,
+		q: db.log().Find(q),
+	}
+}
+
+func (db *DB) LogByID(id bson.ObjectId) (*Log, error) {
+	var log Log
+	if err := db.FindLogs(bson.M{"_id": id}).One(&log); err != nil {
+		return nil, err
+	}
+	return &log, nil
+}
+
+func (db *DB) CreateLog(log *Log) error {
+	log.ID = bson.NewObjectId()
+	log.CreationTime = time.Now().UTC()
+	return db.log().Insert(log)
+}

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -21,14 +21,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-type bytesReadCloser struct {
-	*bytes.Buffer
-}
-
-func (r bytesReadCloser) Close() error {
-	return nil
-}
-
 type App struct {
 	DB *db.DB
 	g  *gin.Engine
@@ -85,7 +77,7 @@ func (app *App) logErrors(c *gin.Context) {
 		return
 	}
 
-	c.Request.Body = bytesReadCloser{bytes.NewBuffer(body)}
+	c.Request.Body = ioutil.NopCloser(bytes.NewReader(body))
 	c.Next()
 
 	if len(c.Errors) == 0 {

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -261,6 +261,7 @@ func (app *App) setupRoutes() {
 			c.JSON(http.StatusConflict, gin.H{
 				"reason": "user already exists",
 			})
+			c.Abort()
 		default:
 			c.AbortWithError(http.StatusInternalServerError, err)
 		}
@@ -363,6 +364,7 @@ func (app *App) setupRoutes() {
 		switch err := app.DB.CreateFeed(feed); {
 		case db.IsDup(err):
 			c.JSON(http.StatusConflict, gin.H{"reason": "duplicate url found"})
+			c.Abort()
 			return
 		case err != nil:
 			c.AbortWithError(http.StatusInternalServerError, err)

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/robfig/cron"
 
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -340,7 +341,11 @@ func (app *App) setupRoutes() {
 
 		var feed db.Feed
 		if err := app.DB.FindFeeds(query).One(&feed); err != nil {
-			c.AbortWithError(http.StatusNotFound, err)
+			if err == mgo.ErrNotFound {
+				c.AbortWithStatus(http.StatusNotFound)
+			} else {
+				c.AbortWithError(http.StatusInternalServerError, err)
+			}
 			return
 		}
 

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/robfig/cron"
 
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -341,7 +340,7 @@ func (app *App) setupRoutes() {
 
 		var feed db.Feed
 		if err := app.DB.FindFeeds(query).One(&feed); err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				c.AbortWithStatus(http.StatusNotFound)
 			} else {
 				c.AbortWithError(http.StatusInternalServerError, err)

--- a/src/github.com/cjlucas/unnamedcast/worker/workers.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers.go
@@ -179,8 +179,6 @@ func (w *ScrapeiTunesFeeds) Work(q *koda.Queue, j *koda.Job) error {
 			continue
 		}
 
-		fmt.Printf("#%v\n", feed)
-
 		_, err = koda.Submit(queueUpdateFeed, 0, &UpdateFeedPayload{
 			FeedID: feed.ID,
 		})


### PR DESCRIPTION
Whenever an unsuccessful response is given, the error should be logged. Logging it to the database would allow for endpoints to be written to retrieve this information (for say, a dashboard).

Handling common errors will also be addressed in this PR:
- `404` responses should not log an error
- Duplicate inserts (causing an error due to unique index constraints) shall return `409` instead of `500`