### PR TITLE
Store item summary

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/api/api.go
+++ b/src/github.com/cjlucas/unnamedcast/api/api.go
@@ -52,6 +52,7 @@ type Item struct {
 	GUID             string        `json:"guid"`
 	Link             string        `json:"link"`
 	Title            string        `json:"title"`
+	Summary          string        `json:"summary"`
 	Description      string        `json:"description"`
 	URL              string        `json:"url"`
 	Author           string        `json:"author"`

--- a/src/github.com/cjlucas/unnamedcast/server/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/feed.go
@@ -43,6 +43,7 @@ type Item struct {
 	Title            string        `json:"title" bson:"title"`
 	URL              string        `json:"url" bson:"url"`
 	Author           string        `json:"author" bson:"author"`
+	Summary          string        `json:"summary" bson:"summary"`
 	Description      string        `json:"description" bson:"description"`
 	Duration         time.Duration `json:"duration" bson:"duration"`
 	Size             int           `json:"size" bson:"size"`

--- a/src/github.com/cjlucas/unnamedcast/worker/workers.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers.go
@@ -365,19 +365,30 @@ func itemsFromRSS(doc *rss.Document) []api.Item {
 		jsonItem.ImageURL = item.Image.URL
 		jsonItem.Link = item.Link
 
-		// Choose one description, break when first preferred description is found
-		descriptions := []string{
+		// Choose one description and one summary
+		// break when first preferred description is found
+
+		chooseOne := func(s *string, choices []string) {
+			for _, c := range choices {
+				if c != "" {
+					*s = c
+					break
+				}
+			}
+		}
+
+		chooseOne(&jsonItem.Summary, []string{
+			item.ITunesSummary,
+			item.ITunesSubtitle,
+			item.Description,
+		})
+
+		chooseOne(&jsonItem.Description, []string{
 			item.ContentEncoded,
 			item.ITunesSummary,
 			item.Description,
-		}
-
-		for _, desc := range descriptions {
-			if desc != "" {
-				jsonItem.Description = desc
-				break
-			}
-		}
+			jsonItem.Summary,
+		})
 	}
 
 	return items


### PR DESCRIPTION
Currently, we only store a single description which comes from either of the following tags:
- `content:encoded`
- `itunes:summary`
- `description`

Instead, a summary along with a description shall be stored.

Tags for getting summary (in this order; first one wins):
- `itunes:summary`
- `itunes:subtitle`
- `description`

Tags for getting description:
- `content:encoded`
- `description`

**Note:** All HTML tags shall be removed from the summary, but left in description (if present).