### PR TITLE
Optimize item state endpoints

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/api/api.go
+++ b/src/github.com/cjlucas/unnamedcast/api/api.go
@@ -23,9 +23,9 @@ type User struct {
 }
 
 type ItemState struct {
-	FeedID   string  `json:"feed_id"`
-	ItemGUID string  `json:"item_guid"`
-	Position float64 `json:"position"` // 0 if item is unplayed
+	ItemID           string    `json:"item_id"`
+	Position         float64   `json:"position"` // 0 if item is unplayed
+	ModificationTime time.Time `json:"modification_time"`
 }
 
 type Feed struct {
@@ -130,6 +130,21 @@ func (api *API) UpdateUserFeeds(userID string, feedIDs []string) error {
 	})
 }
 
+func (api *API) UpdateUserItemState(userID string, state ItemState) error {
+	return api.makeRequest(&apiRoundTrip{
+		Method:      "PUT",
+		Endpoint:    fmt.Sprintf("/api/users/%s/states/%s", userID, state.ItemID),
+		RequestBody: &state,
+	})
+}
+
+func (api *API) DeleteUserItemState(userID, itemID string) error {
+	return api.makeRequest(&apiRoundTrip{
+		Method:   "DELETE",
+		Endpoint: fmt.Sprintf("/api/users/%s/states/%s", userID, itemID),
+	})
+}
+
 func (api *API) GetFeed(feedID string) (*Feed, error) {
 	var feed Feed
 	err := api.makeRequest(&apiRoundTrip{
@@ -191,12 +206,14 @@ func (api *API) FeedForURL(feedURL string) (*Feed, error) {
 
 func (api *API) CreateFeedItem(feedID string, item *Item) error {
 	return api.makeRequest(&apiRoundTrip{
-		Method:      "POST",
-		Endpoint:    fmt.Sprintf("/api/feeds/%s/items", feedID),
-		RequestBody: item,
+		Method:       "POST",
+		Endpoint:     fmt.Sprintf("/api/feeds/%s/items", feedID),
+		RequestBody:  item,
+		ResponseBody: item,
 	})
 }
 
+// TODO: have this modify the passed in item instead of creating a new item
 func (api *API) UpdateFeedItem(feedID string, item *Item) (*Item, error) {
 	var out Item
 	err := api.makeRequest(&apiRoundTrip{
@@ -226,14 +243,6 @@ func (api *API) GetFeedsUsers(feedID string) ([]User, error) {
 		ResponseBody: &users,
 	})
 	return users, err
-}
-
-func (api *API) PutItemStates(userID string, states []ItemState) error {
-	return api.makeRequest(&apiRoundTrip{
-		Method:      "PUT",
-		Endpoint:    fmt.Sprintf("/api/users/%s/states", userID),
-		RequestBody: &states,
-	})
 }
 
 func (api *API) GetUsers() ([]User, error) {

--- a/src/github.com/cjlucas/unnamedcast/api/api.go
+++ b/src/github.com/cjlucas/unnamedcast/api/api.go
@@ -13,6 +13,14 @@ import (
 
 var httpClient = http.Client{}
 
+type itemState int
+
+const (
+	StateUnplayed   itemState = 0
+	StateInProgress           = 1
+	StatePlayed               = 2
+)
+
 type User struct {
 	ID               string      `json:"id"`
 	Username         string      `json:"username"`
@@ -24,6 +32,7 @@ type User struct {
 
 type ItemState struct {
 	ItemID           string    `json:"item_id"`
+	State            itemState `json:"state"`
 	Position         float64   `json:"position"` // 0 if item is unplayed
 	ModificationTime time.Time `json:"modification_time"`
 }

--- a/src/github.com/cjlucas/unnamedcast/server/app_test.go
+++ b/src/github.com/cjlucas/unnamedcast/server/app_test.go
@@ -22,7 +22,7 @@ var emptyObjectID bson.ObjectId
 
 func init() {
 	gin.SetMode(gin.TestMode)
-	gin.DefaultWriter, _ = os.Open(os.DevNull)
+	// gin.DefaultWriter, _ = os.Open(os.DevNull)
 }
 
 func newTestApp() *App {
@@ -398,6 +398,7 @@ func TestPutUserItemState_WithOutdatedState(t *testing.T) {
 
 	state := api.ItemState{
 		ItemID:   item.ID.Hex(),
+		State:    api.StateInProgress,
 		Position: 5,
 	}
 
@@ -432,6 +433,7 @@ func TestDeleteUserItemState(t *testing.T) {
 
 	user.ItemStates = append(user.ItemStates, db.ItemState{
 		ItemID:   item.ID,
+		State:    api.StatePlayed,
 		Position: 0,
 	})
 

--- a/src/github.com/cjlucas/unnamedcast/server/app_test.go
+++ b/src/github.com/cjlucas/unnamedcast/server/app_test.go
@@ -402,8 +402,6 @@ func TestPutUserItemState_WithOutdatedState(t *testing.T) {
 		Position: 5,
 	}
 
-	fmt.Println(state)
-
 	req := newRequest("PUT", fmt.Sprintf("/api/users/%s/states/%s", user.ID.Hex(), state.ItemID), &state)
 	testEndpoint(t, endpointTestInfo{
 		App:          app,
@@ -411,8 +409,6 @@ func TestPutUserItemState_WithOutdatedState(t *testing.T) {
 		ExpectedCode: http.StatusOK,
 		ResponseBody: &state,
 	})
-
-	fmt.Println(state)
 
 	state.ModificationTime = state.ModificationTime.Add(-1 * time.Second)
 

--- a/src/github.com/cjlucas/unnamedcast/server/db/db.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 )
 
 var ErrNotFound = mgo.ErrNotFound
+var ErrOutdatedResource = errors.New("resource is out of date")
 
 func IsDup(err error) bool {
 	return mgo.IsDup(err)

--- a/src/github.com/cjlucas/unnamedcast/server/db/user.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/user.go
@@ -105,7 +105,7 @@ func (db *DB) UpsertUserState(userID bson.ObjectId, state *ItemState) error {
 
 		// Push the state on the front of the array to keep the array
 		// sorted by modification time (desc). In a normal use-case, this will
-		// allow the $set operation above to be performed quicker
+		// improve the speed of the initial update operation
 		return db.users().Update(sel, bson.M{
 			"$push": bson.M{
 				"states": bson.M{

--- a/src/github.com/cjlucas/unnamedcast/server/db/user.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/user.go
@@ -38,6 +38,13 @@ func (db *DB) FindUsers(q interface{}) Query {
 	}
 }
 
+func (db *DB) UserPipeline(pipeline interface{}) *Pipe {
+	return &Pipe{
+		s: db.s,
+		p: db.users().Pipe(pipeline),
+	}
+}
+
 func (db *DB) FindUserByID(id bson.ObjectId) Query {
 	return db.FindUsers(bson.M{"_id": id})
 }

--- a/src/github.com/cjlucas/unnamedcast/server/db/user.go
+++ b/src/github.com/cjlucas/unnamedcast/server/db/user.go
@@ -9,10 +9,19 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+type itemState int
+
+const (
+	stateUnplayed itemState = 0
+	stateInProgress
+	statePlayed
+)
+
 // ItemState represents the state of an unplayed/in progress items
 // Played items will not have an associated state.
 type ItemState struct {
 	ItemID           bson.ObjectId `json:"item_id" bson:"item_id"`
+	State            itemState     `json:"state" bson:"state"`
 	Position         float64       `json:"position" bson:"position"` // 0 if item is unplayed
 	ModificationTime time.Time     `json:"modification_time" bson:"modification_time"`
 }

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -328,9 +328,7 @@ func (app *App) setupRoutes() {
 			}
 		} else {
 			pipeline := []bson.M{
-				{"$match": bson.M{
-					"_id": userID,
-				}},
+				{"$match": bson.M{"_id": userID}},
 				{"$project": bson.M{
 					"states": bson.M{
 						"$filter": bson.M{

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -311,27 +311,6 @@ func (app *App) setupRoutes() {
 		c.JSON(http.StatusOK, &user.ItemStates)
 	})
 
-	// PUT /api/users/:id/states
-	api.PUT("/users/:id/states", app.loadUserWithID("id"), func(c *gin.Context) {
-		user := c.MustGet("user").(*db.User)
-
-		var states []db.ItemState
-		if err := c.BindJSON(&states); err != nil {
-			c.AbortWithError(http.StatusBadRequest, err)
-			return
-		}
-
-		user.ItemStates = states
-		if err := app.DB.UpdateUser(user); err != nil {
-			c.AbortWithError(http.StatusInternalServerError, err)
-			return
-		}
-
-		// TODO(clucas): Return user instead of user.ItemStates to be consistent
-		// with PUT /api/users/:id/feeds
-		c.JSON(http.StatusOK, &user.ItemStates)
-	})
-
 	api.PUT("/users/:id/states/:itemID", app.requireUserID("id"), app.requireItemID("itemID"), func(c *gin.Context) {
 		userID := c.MustGet("userID").(bson.ObjectId)
 		itemID := c.MustGet("itemID").(bson.ObjectId)
@@ -492,7 +471,7 @@ func (app *App) setupRoutes() {
 	api.GET("/feeds/:id/users", app.requireFeedID("id"), func(c *gin.Context) {
 		id := c.MustGet("feedID").(bson.ObjectId)
 		query := bson.M{
-			"feedids": bson.M{
+			"feed_ids": bson.M{
 				"$in": []bson.ObjectId{id},
 			},
 		}

--- a/src/github.com/cjlucas/unnamedcast/worker/workers.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/cjlucas/unnamedcast/api"
 	"github.com/cjlucas/unnamedcast/koda"
@@ -295,8 +296,9 @@ func (w *UpdateFeedWorker) Work(q *koda.Queue, j *koda.Job) error {
 		user := &users[i]
 		for j := range newItems {
 			err := w.API.UpdateUserItemState(user.ID, api.ItemState{
-				ItemID:   newItems[j].ID,
-				Position: 0,
+				ItemID:           newItems[j].ID,
+				State:            api.StateUnplayed,
+				ModificationTime: time.Now().UTC(),
 			})
 			if err != nil {
 				fmt.Println("Could not update user's item state")

--- a/src/github.com/cjlucas/unnamedcast/worker/workers.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers.go
@@ -253,8 +253,8 @@ func (w *UpdateFeedWorker) Work(q *koda.Queue, j *koda.Job) error {
 		}
 	}
 
-	for _, item := range newItems {
-		if err := w.API.CreateFeedItem(payload.FeedID, &item); err != nil {
+	for i := range newItems {
+		if err := w.API.CreateFeedItem(payload.FeedID, &newItems[i]); err != nil {
 			return err
 		}
 	}
@@ -294,16 +294,14 @@ func (w *UpdateFeedWorker) Work(q *koda.Queue, j *koda.Job) error {
 	for i := range users {
 		user := &users[i]
 		for j := range newItems {
-			user.ItemStates = append(user.ItemStates, api.ItemState{
-				FeedID:   feed.ID,
-				ItemGUID: newItems[j].GUID,
+			err := w.API.UpdateUserItemState(user.ID, api.ItemState{
+				ItemID:   newItems[j].ID,
 				Position: 0,
 			})
-		}
-
-		if err := w.API.PutItemStates(user.ID, user.ItemStates); err != nil {
-			fmt.Println("Error saving states (will continue):", err)
-			continue
+			if err != nil {
+				fmt.Println("Could not update user's item state")
+				continue
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, there are two endpoints for accessing and modifying a user's item states:

- `GET /api/users/:id/states`
- `PUT /api/users/:id/states`

These endpoints require the client to upload and download the entire array of states when syncing. This is overkill 99% of the time, and if a user has a large number of states (>2000), the sync speed is detrimental to the experience.

## Proposed Changes ##
- Add `state` field to `ItemState`
  - Allows client be notified of items that were marked as played on other devices.
  - Enum
    - `Unplayed = 0`
    - `InProgress = 1`
    - `Played = 2`
- Replace old `PUT /api/users/:id/states` with `PUT /api/users/:id/states/:itemID`
  - Typical client usage calls for only updating one state at a time
- Store modification time in state object
  - This would allow the client to resolve a conflict
- Add `modified_since` as optional parameter to `GET /api/users/:id/states`
- Add `DELETE /api/users/:id/states/:itemID`
  - Not for use by clients, could be used for pruning inactive item states
    - Inactive meaning any state that every currently connected client is aware of
    - Support for determining whether an item state is active or not has not been implemented (#26)