### PR TITLE
Add pagination and sorting to REST endpoints

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/server/app_test.go
+++ b/src/github.com/cjlucas/unnamedcast/server/app_test.go
@@ -22,7 +22,7 @@ var emptyObjectID bson.ObjectId
 
 func init() {
 	gin.SetMode(gin.TestMode)
-	gin.DefaultWriter, _ = os.Open(os.DevNull)
+	// gin.DefaultWriter, _ = os.Open(os.DevNull)
 }
 
 func newTestApp() *App {
@@ -525,10 +525,56 @@ func TestGetFeed(t *testing.T) {
 }
 
 func TestGetFeedWithoutParams(t *testing.T) {
+	app := newTestApp()
+	createFeed(t, app, &db.Feed{URL: "http://google.com"})
+	createFeed(t, app, &db.Feed{URL: "http://google2.com"})
+
+	var out []db.Feed
 	testEndpoint(t, endpointTestInfo{
+		App:          app,
 		Request:      newRequest("GET", "/api/feeds", nil),
-		ExpectedCode: http.StatusBadRequest,
+		ExpectedCode: http.StatusOK,
+		ResponseBody: &out,
 	})
+
+	if len(out) != 2 {
+		t.Errorf("Feed count mismatch: %d != %d", len(out), 2)
+	}
+}
+
+func TestGetFeedSortedByModificationTime(t *testing.T) {
+	app := newTestApp()
+	feed1 := createFeed(t, app, &db.Feed{
+		URL:              "http://google.com",
+		ModificationTime: time.Now(),
+	})
+	feed2 := createFeed(t, app, &db.Feed{
+		URL:              "http://google2.com",
+		ModificationTime: time.Now(),
+	})
+
+	var out []db.Feed
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      newRequest("GET", "/api/feeds?sort_by=modification_time&sort_order=asc", nil),
+		ExpectedCode: http.StatusOK,
+		ResponseBody: &out,
+	})
+
+	if len(out) != 2 || out[0].URL != feed1.URL || out[1].URL != feed2.URL {
+		t.Error("feed order is incorrect sort_order=asc")
+	}
+
+	testEndpoint(t, endpointTestInfo{
+		App:          app,
+		Request:      newRequest("GET", "/api/feeds?sort_by=modification_time&sort_order=desc", nil),
+		ExpectedCode: http.StatusOK,
+		ResponseBody: &out,
+	})
+
+	if len(out) != 2 || out[0].URL != feed2.URL || out[1].URL != feed1.URL {
+		t.Error("feed order is incorrect sort_order=desc")
+	}
 }
 
 func TestGetFeedByURL(t *testing.T) {

--- a/src/github.com/cjlucas/unnamedcast/server/app_test.go
+++ b/src/github.com/cjlucas/unnamedcast/server/app_test.go
@@ -22,7 +22,7 @@ var emptyObjectID bson.ObjectId
 
 func init() {
 	gin.SetMode(gin.TestMode)
-	// gin.DefaultWriter, _ = os.Open(os.DevNull)
+	gin.DefaultWriter, _ = os.Open(os.DevNull)
 }
 
 func newTestApp() *App {

--- a/src/github.com/cjlucas/unnamedcast/server/main.go
+++ b/src/github.com/cjlucas/unnamedcast/server/main.go
@@ -78,7 +78,7 @@ func ensureQueryExists(c *gin.Context) *db.Query {
 	return q
 }
 
-func parseSortParams(sortableFields ...string) gin.HandlerFunc {
+func parseSortParams(mi db.ModelInfo, sortableFields ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		field := c.Query("sort_by")
 		order := c.Query("sort_order")
@@ -87,6 +87,7 @@ func parseSortParams(sortableFields ...string) gin.HandlerFunc {
 		}
 		if order == "" {
 			c.AbortWithError(http.StatusBadRequest, errors.New("sort_by given without sort_order"))
+			return
 		}
 
 		found := false
@@ -99,7 +100,15 @@ func parseSortParams(sortableFields ...string) gin.HandlerFunc {
 
 		if !found {
 			c.AbortWithError(http.StatusBadRequest, fmt.Errorf("\"%s\" is not a sortable field", field))
+			return
 		}
+
+		info, ok := mi.LookupAPIName(field)
+		if !ok {
+			c.AbortWithError(http.StatusBadRequest, fmt.Errorf("\"%s\" is not a known field", field))
+			return
+		}
+		field = info.BSONName
 
 		query := ensureQueryExists(c)
 		query.SortField = field
@@ -274,13 +283,17 @@ func (app *App) setupRoutes() {
 	api := app.g.Group("/api", app.logErrors)
 
 	// GET /api/users
-	api.GET("/users", func(c *gin.Context) {
-		var users []db.User
-		if err := app.DB.Users.Find(nil).All(&users); err != nil {
-			c.AbortWithError(http.StatusInternalServerError, err)
-		}
-		c.JSON(http.StatusOK, users)
-	})
+	api.GET("/users",
+		parseSortParams(app.DB.Users.ModelInfo, "modification_time"),
+		parseLimitParams,
+		func(c *gin.Context) {
+			var users []db.User
+			if err := app.DB.Users.Find(nil).All(&users); err != nil {
+				c.AbortWithError(http.StatusInternalServerError, err)
+			}
+			c.JSON(http.StatusOK, users)
+		},
+	)
 
 	// POST /api/users
 	api.POST("/users", func(c *gin.Context) {
@@ -390,7 +403,7 @@ func (app *App) setupRoutes() {
 		}
 	})
 
-	api.DELETE("/users/:id/states/:itemID", []gin.HandlerFunc{
+	api.DELETE("/users/:id/states/:itemID",
 		app.requireUserID("id"),
 		app.requireItemID("itemID"),
 		func(c *gin.Context) {
@@ -404,47 +417,54 @@ func (app *App) setupRoutes() {
 
 			c.Status(http.StatusOK)
 		},
-	}...)
+	)
 
+	// GET /api/feeds
 	// GET /api/feeds?url=http://url.com
 	// GET /api/feeds?itunes_id=43912431
-	api.GET("/feeds", parseSortParams("modification_time"), parseLimitParams, func(c *gin.Context) {
-		query := ensureQueryExists(c)
+	//
+	// TODO: modify the ?url and ?itunes_id variants to return a list for consistency
+	api.GET("/feeds",
+		parseSortParams(app.DB.Feeds.ModelInfo, "modification_time"),
+		parseLimitParams,
+		func(c *gin.Context) {
+			query := ensureQueryExists(c)
 
-		if val := c.Query("url"); val != "" {
-			query.Filter = bson.M{"url": val}
-		} else if val := c.Query("itunes_id"); val != "" {
-			id, err := strconv.Atoi(val)
-			if err != nil {
-				c.AbortWithError(http.StatusBadRequest, err)
+			if val := c.Query("url"); val != "" {
+				query.Filter = bson.M{"url": val}
+			} else if val := c.Query("itunes_id"); val != "" {
+				id, err := strconv.Atoi(val)
+				if err != nil {
+					c.AbortWithError(http.StatusBadRequest, err)
+					return
+				}
+				query.Filter = bson.M{"itunes_id": id}
+			}
+
+			if query.Filter == nil {
+				var feeds []db.Feed
+				if err := app.DB.Feeds.Find(query).All(&feeds); err != nil {
+					c.AbortWithError(http.StatusInternalServerError, err)
+				} else {
+					c.JSON(http.StatusOK, feeds)
+				}
 				return
 			}
-			query.Filter = bson.M{"itunes_id": id}
-		}
 
-		if query.Filter == nil {
-			var feeds []db.Feed
-			if err := app.DB.Feeds.Find(query).All(&feeds); err != nil {
-				c.AbortWithError(http.StatusInternalServerError, err)
-			} else {
-				c.JSON(http.StatusOK, feeds)
+			// TODO: use a switch here
+			var feed db.Feed
+			if err := app.DB.Feeds.Find(query).One(&feed); err != nil {
+				if err == db.ErrNotFound {
+					c.AbortWithStatus(http.StatusNotFound)
+				} else {
+					c.AbortWithError(http.StatusInternalServerError, err)
+				}
+				return
 			}
-			return
-		}
 
-		// TODO: use a switch here
-		var feed db.Feed
-		if err := app.DB.Feeds.Find(query).One(&feed); err != nil {
-			if err == db.ErrNotFound {
-				c.AbortWithStatus(http.StatusNotFound)
-			} else {
-				c.AbortWithError(http.StatusInternalServerError, err)
-			}
-			return
-		}
-
-		c.JSON(200, &feed)
-	})
+			c.JSON(http.StatusOK, &feed)
+		},
+	)
 
 	// POST /api/feeds
 	api.POST("/feeds", unmarshalFeed, func(c *gin.Context) {
@@ -502,42 +522,46 @@ func (app *App) setupRoutes() {
 
 	// GET /api/feeds/:id/items[?modified_since=2006-01-02T15:04:05Z07:00]
 	// NOTE: modified_since date check is strictly greater than
-	api.GET("/feeds/:id/items", parseSortParams("modification_time"), parseLimitParams, app.requireFeedID("id"), func(c *gin.Context) {
-		query := ensureQueryExists(c)
-		feedID := c.MustGet("feedID").(bson.ObjectId)
-		modifiedSince := c.Query("modified_since")
+	api.GET("/feeds/:id/items",
+		parseSortParams(app.DB.Items.ModelInfo, "modification_time"),
+		parseLimitParams,
+		app.requireFeedID("id"),
+		func(c *gin.Context) {
+			query := ensureQueryExists(c)
+			feedID := c.MustGet("feedID").(bson.ObjectId)
+			modifiedSince := c.Query("modified_since")
 
-		var modifiedSinceDate time.Time
-		if modifiedSince != "" {
-			t, err := time.Parse(time.RFC3339, modifiedSince)
+			var modifiedSinceDate time.Time
+			if modifiedSince != "" {
+				t, err := time.Parse(time.RFC3339, modifiedSince)
+				if err != nil {
+					c.AbortWithError(http.StatusBadRequest, err)
+					return
+				}
+				modifiedSinceDate = t
+			}
+
+			feed, err := app.DB.Feeds.FeedByID(feedID)
 			if err != nil {
-				c.AbortWithError(http.StatusBadRequest, err)
+				c.AbortWithError(http.StatusInternalServerError, err)
 				return
 			}
-			modifiedSinceDate = t
-		}
 
-		feed, err := app.DB.Feeds.FeedByID(feedID)
-		if err != nil {
-			c.AbortWithError(http.StatusInternalServerError, err)
-			return
-		}
+			query.Filter = bson.M{
+				"_id": bson.M{"$in": feed.Items},
+			}
+			if !modifiedSinceDate.IsZero() {
+				query.Filter["modification_time"] = bson.M{"$gt": modifiedSinceDate}
+			}
 
-		query.Filter = bson.M{
-			"_id": bson.M{"$in": feed.Items},
-		}
-		if !modifiedSinceDate.IsZero() {
-			query.Filter["modification_time"] = bson.M{"$gt": modifiedSinceDate}
-		}
+			var items []db.Item
+			if err := app.DB.Items.Find(query).All(&items); err != nil {
+				c.AbortWithError(http.StatusInternalServerError, err)
+				return
+			}
 
-		var items []db.Item
-		if err := app.DB.Items.Find(query).All(&items); err != nil {
-			c.AbortWithError(http.StatusInternalServerError, err)
-			return
-		}
-
-		c.JSON(http.StatusOK, &items)
-	})
+			c.JSON(http.StatusOK, &items)
+		})
 
 	// GET /api/feeds/:id/users
 	api.GET("/feeds/:id/users", app.requireFeedID("id"), func(c *gin.Context) {


### PR DESCRIPTION
Common URL parameters for pagination and sorting should be added to the following endpoints:

* `GET /api/users`
* `GET /api/feeds`
* `GET /api/feeds/:id/items`

## Pagination ##

* `limit=`
* `offset` should not be allowed due to poor performance

## Sorting ##

* `sort_by=<fieldname>`
  * Should limit which fields can be sorted, due to indexing concerns
  * Implementation idea: Add ability to specify allowed fields per route by using an http handler factory function
* `sort_order=<asc|dsc>`