### PR TITLE
Race condition on feed item creation (POST /api/feeds/:id/items)

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/db/collection.go
+++ b/src/github.com/cjlucas/unnamedcast/db/collection.go
@@ -84,6 +84,11 @@ func (c collection) insert(model interface{}) error {
 	return c.c.Insert(model)
 }
 
+func (c collection) upsert(selector M, model interface{}) error {
+	_, err := c.c.Upsert(selector, model)
+	return err
+}
+
 // filterCond builds the "cond" value of a $filter operation from a Query.
 // More specifically, it converts the specified query.Filter into the expression
 // format required by the aggregation. varName is the variable name specified

--- a/src/github.com/cjlucas/unnamedcast/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed.go
@@ -101,10 +101,12 @@ func (c ItemCollection) Create(item *Item) error {
 	if item.FeedID == emptyID {
 		return errors.New("feed id not set")
 	}
-	item.ID = NewID()
+	if item.ID == emptyID {
+		item.ID = NewID()
+	}
 	item.CreationTime = utctime.Now()
 	item.ModificationTime = utctime.Now()
-	return c.insert(item)
+	return c.upsert(M{"guid": item.GUID, "feed_id": item.FeedID}, item)
 }
 
 func (c ItemCollection) Update(item *Item) error {

--- a/src/github.com/cjlucas/unnamedcast/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"time"
 
 	"github.com/cjlucas/unnamedcast/db/utctime"
@@ -95,6 +96,11 @@ type ItemCollection struct {
 }
 
 func (c ItemCollection) Create(item *Item) error {
+	// Put a method on ID to check for empty ID
+	var emptyID ID
+	if item.FeedID == emptyID {
+		return errors.New("feed id not set")
+	}
 	item.ID = NewID()
 	item.CreationTime = utctime.Now()
 	item.ModificationTime = utctime.Now()
@@ -112,4 +118,10 @@ func (c ItemCollection) Update(item *Item) error {
 	}
 
 	return c.c.UpdateId(origItem.ID, &origItem)
+}
+
+func (c ItemCollection) ItemsWithFeedID(feedID ID) *Result {
+	return c.Find(&Query{
+		Filter: M{"feed_id": feedID},
+	})
 }

--- a/src/github.com/cjlucas/unnamedcast/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed.go
@@ -28,7 +28,7 @@ type Feed struct {
 type Item struct {
 	ID               ID            `json:"id" bson:"_id,omitempty"`
 	FeedID           ID            `json:"-" bson:"feed_id" index:"feed_id"`
-	GUID             string        `json:"guid" bson:"guid"`
+	GUID             string        `json:"guid" bson:"guid" index:"guid"`
 	Link             string        `json:"link" bson:"link"`
 	Title            string        `json:"title" bson:"title"`
 	URL              string        `json:"url" bson:"url"`

--- a/src/github.com/cjlucas/unnamedcast/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed.go
@@ -11,7 +11,6 @@ type Feed struct {
 	Title             string       `json:"title" bson:"title" index:",text"`
 	URL               string       `json:"url" bson:"url" index:",unique"`
 	Author            string       `json:"author" bson:"author"`
-	Items             []ID         `json:"items" bson:"items"`
 	CreationTime      utctime.Time `json:"creation_time" bson:"creation_time"`
 	ModificationTime  utctime.Time `json:"modification_time" bson:"modification_time" index:"modification_time"`
 	ImageURL          string       `json:"image_url" bson:"image_url"`
@@ -25,18 +24,9 @@ type Feed struct {
 	} `json:"category"`
 }
 
-func (f *Feed) HasItemWithID(id ID) bool {
-	for i := range f.Items {
-		if f.Items[i] == id {
-			return true
-		}
-	}
-
-	return false
-}
-
 type Item struct {
 	ID               ID            `json:"id" bson:"_id,omitempty"`
+	FeedID           ID            `json:"-" bson:"feed_id" index:"feed_id"`
 	GUID             string        `json:"guid" bson:"guid"`
 	Link             string        `json:"link" bson:"link"`
 	Title            string        `json:"title" bson:"title"`

--- a/src/github.com/cjlucas/unnamedcast/db/feed_test.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed_test.go
@@ -10,6 +10,14 @@ func createFeed(t *testing.T, db *DB, feed *Feed) *Feed {
 	return feed
 }
 
+func createItem(t *testing.T, db *DB, item *Item) *Item {
+	if err := db.Items.Create(item); err != nil {
+		t.Fatal("Could not create item:", err)
+	}
+
+	return item
+}
+
 func TestCreateFeed(t *testing.T) {
 	db := newDB()
 
@@ -26,7 +34,8 @@ func TestUpdateItem_NoModification(t *testing.T) {
 	db := newDB()
 
 	item := &Item{
-		GUID: "http://google.com/1",
+		GUID:   "http://google.com/1",
+		FeedID: createFeed(t, db, &Feed{URL: "http://google.com"}).ID,
 	}
 
 	if err := db.Items.Create(item); err != nil {
@@ -41,5 +50,25 @@ func TestUpdateItem_NoModification(t *testing.T) {
 
 	if !modTime.Equal(item.ModificationTime) {
 		t.Errorf("ModificationTime mismatch: %s != %s", item.ModificationTime, modTime)
+	}
+}
+
+func TestItemsWithFeedID(t *testing.T) {
+	db := newDB()
+
+	feed := createFeed(t, db, &Feed{URL: "http://google.com"})
+
+	createItem(t, db, &Item{
+		GUID:   "http://google.com/1",
+		FeedID: feed.ID,
+	})
+
+	n, err := db.Items.ItemsWithFeedID(feed.ID).Count()
+	if err != nil {
+		t.Fatalf("ItemsWithFeedID failed: %s", err)
+	}
+
+	if n != 1 {
+		t.Errorf("num items mismatch: %d != 1", n)
 	}
 }

--- a/src/github.com/cjlucas/unnamedcast/db/feed_test.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed_test.go
@@ -72,3 +72,46 @@ func TestItemsWithFeedID(t *testing.T) {
 		t.Errorf("num items mismatch: %d != 1", n)
 	}
 }
+
+func TestCreateItem(t *testing.T) {
+	db := newDB()
+
+	feedID := createFeed(t, db, &Feed{URL: "http://google.com"}).ID
+	createItem(t, db, &Item{
+		GUID:   "http://google.com/1",
+		FeedID: feedID,
+	})
+	createItem(t, db, &Item{
+		GUID:   "http://google.com/2",
+		FeedID: feedID,
+	})
+
+	n, err := db.Items.Find(nil).Count()
+	if err != nil {
+		t.Fatalf("find items failed: %s", err)
+	}
+
+	if n != 2 {
+		t.Errorf("num items mismatch: %d != 2", n)
+	}
+}
+
+func TestCreateItem_Dupe(t *testing.T) {
+	db := newDB()
+
+	item := Item{
+		GUID:   "http://google.com/1",
+		FeedID: createFeed(t, db, &Feed{URL: "http://google.com"}).ID,
+	}
+	createItem(t, db, &item)
+	createItem(t, db, &item)
+
+	n, err := db.Items.Find(nil).Count()
+	if err != nil {
+		t.Fatalf("find items failed: %s", err)
+	}
+
+	if n != 1 {
+		t.Errorf("num items mismatch: %d != 1", n)
+	}
+}

--- a/src/github.com/cjlucas/unnamedcast/server/endpoint/feeds.go
+++ b/src/github.com/cjlucas/unnamedcast/server/endpoint/feeds.go
@@ -141,9 +141,9 @@ func (e *UpdateFeed) Handle(c *gin.Context) {
 }
 
 type GetFeedItems struct {
-	DB    *db.DB
-	Feed  db.Feed
-	Query db.Query
+	DB     *db.DB
+	FeedID db.ID
+	Query  db.Query
 
 	Params struct {
 		sortParams
@@ -159,14 +159,14 @@ func (e *GetFeedItems) Bind() []gin.HandlerFunc {
 		middleware.RequireExistingModel(&middleware.RequireExistingModelOpts{
 			Collection: e.DB.Feeds,
 			BoundName:  "id",
-			Result:     &e.Feed,
+			ID:         &e.FeedID,
 		}),
 	}
 }
 
 func (e *GetFeedItems) Handle(c *gin.Context) {
 	e.Query.Filter = db.M{
-		"_id": db.M{"$in": []db.ID{}},
+		"feed_id": e.FeedID,
 	}
 
 	if !e.Params.ModifiedSince.IsZero() {
@@ -289,7 +289,7 @@ func (e *GetFeedItem) Handle(c *gin.Context) {
 
 type UpdateFeedItem struct {
 	DB     *db.DB
-	Feed   db.Feed
+	FeedID db.ID
 	ItemID db.ID
 	Item   db.Item
 }
@@ -299,7 +299,7 @@ func (e *UpdateFeedItem) Bind() []gin.HandlerFunc {
 		middleware.RequireExistingModel(&middleware.RequireExistingModelOpts{
 			Collection: e.DB.Feeds,
 			BoundName:  "id",
-			Result:     &e.Feed,
+			ID:         &e.FeedID,
 		}),
 		middleware.RequireExistingModel(&middleware.RequireExistingModelOpts{
 			Collection: e.DB.Items,
@@ -312,6 +312,7 @@ func (e *UpdateFeedItem) Bind() []gin.HandlerFunc {
 
 func (e *UpdateFeedItem) Handle(c *gin.Context) {
 	e.Item.ID = e.ItemID
+	e.Item.FeedID = e.FeedID
 
 	// if !e.Feed.HasItemWithID(e.Item.ID) {
 	// 	c.AbortWithError(http.StatusNotFound, errors.New("item does not belong to feed"))


### PR DESCRIPTION
In the scenario where update-feed jobs working on the same feed executing simultaneously, there is a possibility that both workers will attempt to create a new item, causing a duplicate in the database.

The way to fix this would be to do a condition upsert, where we would create a new item if it didn't exist, otherwise update the old document.

Our current schema does not support an easy way to do this. An `Item` does not store the feed id to which it belongs. If that is added, the conditional query would be something like Item.GUID == 'whatever' AND Item.FeedID = 'id here'. This would also allow the removal of `Feed.ItemIDs'.