### PR TITLE
Don't update user states on feed's initial update

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/api/api.go
+++ b/src/github.com/cjlucas/unnamedcast/api/api.go
@@ -48,6 +48,7 @@ type Feed struct {
 	ITunesRatingCount int       `json:"itunes_rating_count"`
 	CreationTime      time.Time `json:"creation_time"`
 	ModificationTime  time.Time `json:"modification_time"`
+	LastScrapedTime   time.Time `json:"last_scraped_time"`
 	Items             []string  `json:"items"`
 
 	Category struct {

--- a/src/github.com/cjlucas/unnamedcast/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed.go
@@ -14,6 +14,7 @@ type Feed struct {
 	Author            string       `json:"author" bson:"author"`
 	CreationTime      utctime.Time `json:"creation_time" bson:"creation_time"`
 	ModificationTime  utctime.Time `json:"modification_time" bson:"modification_time" index:"modification_time"`
+	LastScrapedTime   utctime.Time `json:"last_scraped_time" bson:"last_scraped_time"`
 	ImageURL          string       `json:"image_url" bson:"image_url"`
 	ITunesID          int          `json:"itunes_id" bson:"itunes_id" index:"itunes_id"`
 	ITunesReviewCount int          `json:"itunes_review_count" bson:"itunes_review_count"`

--- a/src/github.com/cjlucas/unnamedcast/worker/workers.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers.go
@@ -275,6 +275,7 @@ func (w *UpdateFeedWorker) Work(j *Job) error {
 	feed.URL = origFeed.URL
 	feed.ITunesRatingCount = origFeed.ITunesRatingCount
 	feed.ITunesReviewCount = origFeed.ITunesReviewCount
+	feed.LastScrapedTime = time.Now()
 	if err := w.API.UpdateFeed(feed); err != nil {
 		return err
 	}
@@ -282,6 +283,11 @@ func (w *UpdateFeedWorker) Work(j *Job) error {
 	users, err := w.API.GetFeedsUsers(payload.FeedID)
 	if err != nil {
 		return fmt.Errorf("Failed to get users' feeds: %s", err)
+	}
+
+	// Don't update user feeds on initial scrape
+	if origFeed.LastScrapedTime.IsZero() {
+		return nil
 	}
 
 	for i := range users {


### PR DESCRIPTION
Currently whenever a newly added stub feed is updated, we add every item from that feed as unplayed to every use who is subscribed to that feed. This is likely not the behavior the user wants. Instead, the user states should only be updated if the feed has previously been scraped.

Currently, there is no obvious way to determine if a feed has previously been scraped if there are no items. It may be as simple as checking if `Title == ""`, as we only add the url when creating a stub feed, but this is not guaranteed to be safe in the future. Another option would be to add a `LastScrapedTime` field to `Feed`.