### PR TITLE
Utilize HTTP response headers in UpdateFeedWorker

### DIFF
--- a/src/github.com/cjlucas/unnamedcast/api/api.go
+++ b/src/github.com/cjlucas/unnamedcast/api/api.go
@@ -38,18 +38,20 @@ type ItemState struct {
 }
 
 type Feed struct {
-	ID                string    `json:"id,omitempty"`
-	Title             string    `json:"title"`
-	URL               string    `json:"url"`
-	Author            string    `json:"author"`
-	ImageURL          string    `json:"image_url"`
-	ITunesID          int       `json:"itunes_id"`
-	ITunesReviewCount int       `json:"itunes_review_count"`
-	ITunesRatingCount int       `json:"itunes_rating_count"`
-	CreationTime      time.Time `json:"creation_time"`
-	ModificationTime  time.Time `json:"modification_time"`
-	LastScrapedTime   time.Time `json:"last_scraped_time"`
-	Items             []string  `json:"items"`
+	ID                 string    `json:"id,omitempty"`
+	Title              string    `json:"title"`
+	URL                string    `json:"url"`
+	Author             string    `json:"author"`
+	ImageURL           string    `json:"image_url"`
+	ITunesID           int       `json:"itunes_id"`
+	ITunesReviewCount  int       `json:"itunes_review_count"`
+	ITunesRatingCount  int       `json:"itunes_rating_count"`
+	CreationTime       time.Time `json:"creation_time"`
+	ModificationTime   time.Time `json:"modification_time"`
+	LastScrapedTime    time.Time `json:"last_scraped_time"`
+	Items              []string  `json:"items"`
+	SourceETag         string    `json:"src_etag"`
+	SourceLastModified time.Time `json:"src_last_modified"`
 
 	Category struct {
 		Name          string   `json:"name"`

--- a/src/github.com/cjlucas/unnamedcast/db/feed.go
+++ b/src/github.com/cjlucas/unnamedcast/db/feed.go
@@ -8,17 +8,19 @@ import (
 )
 
 type Feed struct {
-	ID                ID           `bson:"_id,omitempty" json:"id"`
-	Title             string       `json:"title" bson:"title" index:",text"`
-	URL               string       `json:"url" bson:"url" index:",unique"`
-	Author            string       `json:"author" bson:"author"`
-	CreationTime      utctime.Time `json:"creation_time" bson:"creation_time"`
-	ModificationTime  utctime.Time `json:"modification_time" bson:"modification_time" index:"modification_time"`
-	LastScrapedTime   utctime.Time `json:"last_scraped_time" bson:"last_scraped_time"`
-	ImageURL          string       `json:"image_url" bson:"image_url"`
-	ITunesID          int          `json:"itunes_id" bson:"itunes_id" index:"itunes_id"`
-	ITunesReviewCount int          `json:"itunes_review_count" bson:"itunes_review_count"`
-	ITunesRatingCount int          `json:"itunes_rating_count" bson:"itunes_rating_count"`
+	ID                 ID           `bson:"_id,omitempty" json:"id"`
+	Title              string       `json:"title" bson:"title" index:",text"`
+	URL                string       `json:"url" bson:"url" index:",unique"`
+	Author             string       `json:"author" bson:"author"`
+	CreationTime       utctime.Time `json:"creation_time" bson:"creation_time"`
+	ModificationTime   utctime.Time `json:"modification_time" bson:"modification_time" index:"modification_time"`
+	LastScrapedTime    utctime.Time `json:"last_scraped_time" bson:"last_scraped_time"`
+	ImageURL           string       `json:"image_url" bson:"image_url"`
+	ITunesID           int          `json:"itunes_id" bson:"itunes_id" index:"itunes_id"`
+	ITunesReviewCount  int          `json:"itunes_review_count" bson:"itunes_review_count"`
+	ITunesRatingCount  int          `json:"itunes_rating_count" bson:"itunes_rating_count"`
+	SourceETag         string       `json:"src_etag" bson:"src_etag"`
+	SourceLastModified utctime.Time `json:"src_last_modified" bson:"src_last_modified"`
 
 	Category struct {
 		Name          string   `json:"name" bson:"name"`

--- a/src/github.com/cjlucas/unnamedcast/worker/workers.go
+++ b/src/github.com/cjlucas/unnamedcast/worker/workers.go
@@ -233,9 +233,13 @@ func (w *UpdateFeedWorker) Work(j *Job) error {
 		lastModifiedTime, err = time.Parse(time.RFC1123, val)
 		if err != nil {
 			j.Logf("Failed to parse Last-Modified header: %s", err)
-		} else if lastModifiedTime.Equal(origFeed.SourceLastModified) {
-			j.Logf("Last-Modified has not changed since last scrape, will not update")
-			return nil
+		} else {
+			t1 := lastModifiedTime.Truncate(time.Second)
+			t2 := origFeed.SourceLastModified.Truncate(time.Second)
+			if t1.Equal(t2) {
+				j.Logf("Last-Modified has not changed since last scrape, will not update")
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, a feed update (`PUT`) request is sent regardless of if the content of the RSS feed has actually changed. We should be utilizing HTTP response headers such as `Last-Modified` and `ETag` to determine if the RSS feed has actually changed before attempting to perform any updates. This will decrease the load on the API and allow jobs to be processed faster.